### PR TITLE
GSN-4209 - Implement global variables

### DIFF
--- a/Pod/Core/UnusedStepsTracker.m
+++ b/Pod/Core/UnusedStepsTracker.m
@@ -56,6 +56,8 @@
     if (self.bundleCounter == 0) {
         NSMutableSet *unusedSteps = self.allSteps;
         [unusedSteps minusSet: self.executedSteps];
+        // We don't need this since it just checks the steps used in the test run,
+        // so if only running 1 test, a lot of steps will appear here.
         // if (unusedSteps.count > 0) {
         //     self.printUnusedSteps(unusedSteps.allObjects);
         // }

--- a/Pod/Core/UnusedStepsTracker.m
+++ b/Pod/Core/UnusedStepsTracker.m
@@ -56,11 +56,6 @@
     if (self.bundleCounter == 0) {
         NSMutableSet *unusedSteps = self.allSteps;
         [unusedSteps minusSet: self.executedSteps];
-        // We don't need this since it just checks the steps used in the test run,
-        // so if only running 1 test, a lot of steps will appear here.
-        // if (unusedSteps.count > 0) {
-        //     self.printUnusedSteps(unusedSteps.allObjects);
-        // }
     }
 }
 

--- a/Pod/Core/UnusedStepsTracker.m
+++ b/Pod/Core/UnusedStepsTracker.m
@@ -56,9 +56,9 @@
     if (self.bundleCounter == 0) {
         NSMutableSet *unusedSteps = self.allSteps;
         [unusedSteps minusSet: self.executedSteps];
-        if (unusedSteps.count > 0) {
-            self.printUnusedSteps(unusedSteps.allObjects);
-        }
+        // if (unusedSteps.count > 0) {
+        //     self.printUnusedSteps(unusedSteps.allObjects);
+        // }
     }
 }
 

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -56,7 +56,7 @@ open class NativeTestCase: XCGNativeInitializer {
             return []
         }
 
-        if let globalParamFile = Bundle.main.path(forResource: "PlugIns/GherkinUITests.xctest/globalParam", ofType: "json") {
+        if let globalParamFile = Bundle.main.path(forResource: "\(ProcessInfo.processInfo.environment["XCTestBundlePath"])/globalParam", ofType: "json") {
             do {
                 let jsonData = try NSData(contentsOfFile: globalParamFile, options: .mappedIfSafe)
                 ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -55,7 +55,14 @@ open class NativeTestCase: XCGNativeInitializer {
             }
             return []
         }
-        
+
+        if let globalParamFile = Bundle.main.path(forResource: "PlugIns/GherkinUITests.xctest/globalParam", ofType: "json") {
+            do {
+                let jsonData = try NSData(contentsOfFile: globalParamFile, options: .mappedIfSafe)
+                ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary
+            } catch {}
+        }
+
         guard let features = NativeFeatureParser(path: path).parsedFeatures() else {
             assertionFailure("Could not retrieve features from the path '\(path)'")
             return []
@@ -184,6 +191,8 @@ extension XCTestCase {
                 let scenario = NativeScenario(outline.scenarioDescription, steps: steps, index: outline.index + exampleIndex)
                 perform(scenario: scenario)
             }
+        } else if scenario.stepDescriptions.filter({ $0.expression.contains("{{") && $0.expression.contains("}}") }).count > 0 {
+
         } else {
             perform(scenario: scenario)
         }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -56,7 +56,8 @@ open class NativeTestCase: XCGNativeInitializer {
             return []
         }
 
-        if let globalParamFile = Bundle.main.path(forResource: "\(ProcessInfo.processInfo.environment["XCTestBundlePath"])/globalParam", ofType: "json") {
+        if let xctestPath = ProcessInfo.processInfo.environment["XCTestBundlePath"],
+            let globalParamFile = Bundle.main.path(forResource: "\(xctestPath)/globalParam", ofType: "json") {
             do {
                 let jsonData = try NSData(contentsOfFile: globalParamFile, options: .mappedIfSafe)
                 ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -194,8 +194,6 @@ extension XCTestCase {
                 let scenario = NativeScenario(outline.scenarioDescription, steps: steps, index: outline.index + exampleIndex)
                 perform(scenario: scenario)
             }
-        } else if scenario.stepDescriptions.filter({ $0.expression.contains("{{") && $0.expression.contains("}}") }).count > 0 {
-
         } else {
             perform(scenario: scenario)
         }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -57,12 +57,12 @@ open class NativeTestCase: XCGNativeInitializer {
         }
 
         if let xctestPath = ProcessInfo.processInfo.environment["XCTestBundlePath"],
-            let globalParamFile = Bundle.main.path(forResource: "\(xctestPath)/globalParam", ofType: "json") {
+            let globalParamsFile = Bundle.main.path(forResource: "\(xctestPath)/globalParams", ofType: "json") {
             do {
-                let jsonData = try NSData(contentsOfFile: globalParamFile, options: .mappedIfSafe)
+                let jsonData = try NSData(contentsOfFile: globalParamsFile, options: .mappedIfSafe)
                 ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary
             } catch {
-                assertionFailure("Couldn't read the globalParam.json file. Is it valid json?")
+                assertionFailure("Couldn't read the globalParams.json file. Is it valid json?")
             }
         }
 

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -60,7 +60,9 @@ open class NativeTestCase: XCGNativeInitializer {
             do {
                 let jsonData = try NSData(contentsOfFile: globalParamFile, options: .mappedIfSafe)
                 ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary
-            } catch {}
+            } catch {
+                assertionFailure("Couldn't read the globalParam.json file. Is it valid json?)
+            }
         }
 
         guard let features = NativeFeatureParser(path: path).parsedFeatures() else {

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -56,8 +56,7 @@ open class NativeTestCase: XCGNativeInitializer {
             return []
         }
 
-        if let xctestPath = ProcessInfo.processInfo.environment["XCTestBundlePath"],
-            let globalParamsFile = Bundle.main.path(forResource: "\(xctestPath)/globalParams", ofType: "json") {
+        if let globalParamsFile = Bundle(for: self).path(forResource: "globalParams", ofType: "json") {
             do {
                 let jsonData = try NSData(contentsOfFile: globalParamsFile, options: .mappedIfSafe)
                 ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -56,10 +56,10 @@ open class NativeTestCase: XCGNativeInitializer {
             return []
         }
 
-        if let globalParamsFile = Bundle(for: self).path(forResource: "globalParams", ofType: "json") {
+        if let globalParamsFile = Bundle(for: self).url(forResource: "globalParams", withExtension: "json") {
             do {
-                let jsonData = try NSData(contentsOfFile: globalParamsFile, options: .mappedIfSafe)
-                ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData as Data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary
+                let jsonData = try Data(contentsOf: globalParamsFile, options: .mappedIfSafe)
+                ParseState.globalParams = try JSONSerialization.jsonObject(with: jsonData, options: .mutableContainers) as? NSDictionary
             } catch {
                 assertionFailure("Couldn't read the globalParams.json file. Is it valid json?")
             }

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -107,13 +107,14 @@ class ParseState {
             }
             
             for exampleIndex in 0...self.examples.count - 1 {
+                var newSteps = steps
                 var newName = name
                 examples[exampleIndex].pairs.forEach { (key, pair) in
                     let toReplace = "<\(key)>"
                     let replaceWith = pair
                     // newName = newName.replacingOccurrences(of: toReplace, with: replaceWith)
-                    for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(toReplace) {
-                        steps[stepIndex].expression = steps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                    for stepIndex in 0..<newSteps.count where newSteps[stepIndex].expression.contains(toReplace) {
+                        newSteps[stepIndex].expression = newSteps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
                     }
                 }
 
@@ -123,7 +124,7 @@ class ParseState {
                     newName = "\(newName)-\(exampleIndex)"
                 }
 
-                scenarios.append(NativeScenario(newName, steps: steps, index: index, tags: tags))
+                scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))
             }
         }
 

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -17,11 +17,12 @@ class ParseState {
     var steps: [StepDescription]
     var exampleLines: [(lineNumber: Int, line: String)]
     var parsingBackground: Bool
+    static var globalParams: NSDictionary?
 
     convenience init() {
         self.init(name: nil)
     }
-    
+
     required init(name: String?, parsingBackground: Bool = false, tags: [String] = []) {
         self.name = name
         self.tags = tags
@@ -29,22 +30,22 @@ class ParseState {
         exampleLines = []
         self.parsingBackground = parsingBackground
     }
-    
+
     private var examples: [NativeExample] {
         get {
             if self.exampleLines.count < 2 { return [] }
-            
+
             var examples: [NativeExample] = []
-            
+
             // The first line is the titles
             let titles = self.exampleLines.first!.line.components(separatedBy: "|").map { $0.trimmingCharacters(in: whitespace) }
-            
+
             // The other lines are the examples themselves
             self.exampleLines.dropFirst().forEach { rawLine in
                 let line = rawLine.line.components(separatedBy: "|").map { $0.trimmingCharacters(in: whitespace) }
-                
+
                 var pairs: [String: String] = Dictionary()
-                
+
                 (0..<titles.count).forEach { n in
                     // Get the title and value for this column
                     let title = titles[n]
@@ -53,56 +54,83 @@ class ParseState {
                         pairs[title] = value
                     }
                 }
-                
+
                 examples.append( (rawLine.lineNumber, pairs ) )
             }
-            
+
             return examples
         }
     }
 
     func background() -> NativeBackground? {
         guard parsingBackground, let name = self.name, self.steps.count > 0 else { return nil }
-        
+
         return NativeBackground(name, steps: self.steps)
     }
-    
+
     func scenarios(at index: Int) -> [NativeScenario]? {
         guard let name = self.name, self.steps.count > 0 else { return nil }
-        
         var scenarios = Array<NativeScenario>()
-        
+        var steps = self.steps
+        let globalParamOpeningChar = "{{"
+        let globalParamClosingChar = "}}"
+
+        if steps.filter({ $0.expression.contains(globalParamOpeningChar) &&
+            $0.expression.contains(globalParamClosingChar) }).count > 0 &&
+            ParseState.globalParams != nil {
+            for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(globalParamOpeningChar) && steps[stepIndex].expression.contains(globalParamClosingChar) {
+                for (key, value) in ParseState.globalParams! where steps[stepIndex].expression.contains("\(globalParamOpeningChar)\(key)\(globalParamClosingChar)") {
+                    let toReplace = "\(globalParamOpeningChar)\(key)\(globalParamClosingChar)"
+                    let replaceWith = "\(value)"
+                    steps[stepIndex].expression = steps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                }
+            }
+        }
+
         // If we have no examples then we have one scenario.
         // Otherwise we need to make more than one scenario.
         if self.examples.isEmpty {
-            scenarios.append(NativeScenario(name, steps: self.steps, index: index, tags: tags))
+            scenarios.append(NativeScenario(name, steps: steps, index: index, tags: tags))
         } else {
+            var examples = self.examples
+
+            if ParseState.globalParams != nil {
+                for exampleIndex in 0..<examples.count {
+                    for (globalKey, globalValue) in ParseState.globalParams! where examples[exampleIndex].pairs.first(where: { $1.contains("\(globalParamOpeningChar)\(globalKey)\(globalParamClosingChar)") } ) != nil {
+                        let toReplace = "\(globalParamOpeningChar)\(globalKey)\(globalParamClosingChar)"
+                        let replaceWith = "\(globalValue)"
+                        if let key = examples[exampleIndex].pairs.first(where: { $1.contains(toReplace) })?.key {
+                            examples[exampleIndex].pairs[key] = examples[exampleIndex].pairs[key]!.replacingOccurrences(of: toReplace, with: replaceWith)
+                        }
+                    }
+                }
+            }
+            
             for exampleIndex in 0...self.examples.count - 1 {
-                var newSteps = self.steps
                 var newName = name
-                self.examples[exampleIndex].pairs.forEach { (key, pair) in
+                examples[exampleIndex].pairs.forEach { (key, pair) in
                     let toReplace = "<\(key)>"
                     let replaceWith = pair
                     // newName = newName.replacingOccurrences(of: toReplace, with: replaceWith)
-                    for stepIndex in 0...newSteps.count - 1 {
-                        newSteps[stepIndex].expression = newSteps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                    for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(toReplace) {
+                        steps[stepIndex].expression = steps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
                     }
                 }
 
-                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in 
+                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in
                 let nameAlreadyExists = scenarios.firstIndex(where: { $0.name == newName })
                 if (newName == name)  || (nameAlreadyExists != nil) {
                     newName = "\(newName)-\(exampleIndex)"
                 }
 
-                scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))
+                scenarios.append(NativeScenario(newName, steps: steps, index: index, tags: tags))
             }
         }
-        
+
         self.name = nil
         self.steps = []
         self.exampleLines = []
-        
+
         return scenarios
     }
 }

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -75,8 +75,7 @@ class ParseState {
         let globalParamOpeningChar = "{{"
         let globalParamClosingChar = "}}"
 
-        if steps.filter({ $0.expression.contains(globalParamOpeningChar) &&
-            $0.expression.contains(globalParamClosingChar) }).count > 0 &&
+        if steps.filter({ $0.expression.contains(globalParamOpeningChar) &&  $0.expression.contains(globalParamClosingChar) }).count > 0 &&
             ParseState.globalParams != nil {
             for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(globalParamOpeningChar) && steps[stepIndex].expression.contains(globalParamClosingChar) {
                 for (key, value) in ParseState.globalParams! where steps[stepIndex].expression.contains("\(globalParamOpeningChar)\(key)\(globalParamClosingChar)") {

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -17,11 +17,12 @@ class ParseState {
     var steps: [StepDescription]
     var exampleLines: [(lineNumber: Int, line: String)]
     var parsingBackground: Bool
+    static var globalParams: NSDictionary?
 
     convenience init() {
         self.init(name: nil)
     }
-    
+
     required init(name: String?, parsingBackground: Bool = false, tags: [String] = []) {
         self.name = name
         self.tags = tags
@@ -29,22 +30,22 @@ class ParseState {
         exampleLines = []
         self.parsingBackground = parsingBackground
     }
-    
+
     private var examples: [NativeExample] {
         get {
             if self.exampleLines.count < 2 { return [] }
-            
+
             var examples: [NativeExample] = []
-            
+
             // The first line is the titles
             let titles = self.exampleLines.first!.line.components(separatedBy: "|").map { $0.trimmingCharacters(in: whitespace) }
-            
+
             // The other lines are the examples themselves
             self.exampleLines.dropFirst().forEach { rawLine in
                 let line = rawLine.line.components(separatedBy: "|").map { $0.trimmingCharacters(in: whitespace) }
-                
+
                 var pairs: [String: String] = Dictionary()
-                
+
                 (0..<titles.count).forEach { n in
                     // Get the title and value for this column
                     let title = titles[n]
@@ -53,56 +54,83 @@ class ParseState {
                         pairs[title] = value
                     }
                 }
-                
+
                 examples.append( (rawLine.lineNumber, pairs ) )
             }
-            
+
             return examples
         }
     }
 
     func background() -> NativeBackground? {
         guard parsingBackground, let name = self.name, self.steps.count > 0 else { return nil }
-        
+
         return NativeBackground(name, steps: self.steps)
     }
-    
+
     func scenarios(at index: Int) -> [NativeScenario]? {
-        guard let name = self.name, self.steps.count > 0 else { return nil }
-        
+        guard var name = self.name, self.steps.count > 0 else { return nil }
         var scenarios = Array<NativeScenario>()
-        
+        var steps = self.steps
+        let globalParamOpeningChar = "{{"
+        let globalParamClosingChar = "}}"
+
+        if steps.filter({ $0.expression.contains(globalParamOpeningChar) &&
+            $0.expression.contains(globalParamClosingChar) }).count > 0 &&
+            ParseState.globalParams != nil {
+            for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(globalParamOpeningChar) && steps[stepIndex].expression.contains(globalParamClosingChar) {
+                for (key, value) in ParseState.globalParams! where steps[stepIndex].expression.contains("\(globalParamOpeningChar)\(key)\(globalParamClosingChar)") {
+                    let toReplace = "\(globalParamOpeningChar)\(key)\(globalParamClosingChar)"
+                    let replaceWith = "\(value)"
+                    steps[stepIndex].expression = steps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                }
+            }
+        }
+
         // If we have no examples then we have one scenario.
         // Otherwise we need to make more than one scenario.
         if self.examples.isEmpty {
-            scenarios.append(NativeScenario(name, steps: self.steps, index: index, tags: tags))
+            scenarios.append(NativeScenario(name, steps: steps, index: index, tags: tags))
         } else {
+            var examples = self.examples
+
+            if ParseState.globalParams != nil {
+                for exampleIndex in 0..<examples.count {
+                    for (globalKey, globalValue) in ParseState.globalParams! where examples[exampleIndex].pairs.first(where: { $1.contains("\(globalParamOpeningChar)\(globalKey)\(globalParamClosingChar)") } ) != nil {
+                        let toReplace = "\(globalParamOpeningChar)\(globalKey)\(globalParamClosingChar)"
+                        let replaceWith = "\(globalValue)"
+                        if let key = examples[exampleIndex].pairs.first(where: { $1.contains(toReplace) })?.key {
+                            examples[exampleIndex].pairs[key] = examples[exampleIndex].pairs[key]!.replacingOccurrences(of: toReplace, with: replaceWith)
+                        }
+                    }
+                }
+            }
+            
             for exampleIndex in 0...self.examples.count - 1 {
-                var newSteps = self.steps
                 var newName = name
-                self.examples[exampleIndex].pairs.forEach { (key, pair) in
+                examples[exampleIndex].pairs.forEach { (key, pair) in
                     let toReplace = "<\(key)>"
                     let replaceWith = pair
                     // newName = newName.replacingOccurrences(of: toReplace, with: replaceWith)
-                    for stepIndex in 0...newSteps.count - 1 {
-                        newSteps[stepIndex].expression = newSteps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                    for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(toReplace) {
+                        steps[stepIndex].expression = steps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
                     }
                 }
 
-                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in 
+                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in
                 let nameAlreadyExists = scenarios.firstIndex(where: { $0.name == newName })
                 if (newName == name)  || (nameAlreadyExists != nil) {
                     newName = "\(newName)-\(exampleIndex)"
                 }
 
-                scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))
+                scenarios.append(NativeScenario(newName, steps: steps, index: index, tags: tags))
             }
         }
-        
+
         self.name = nil
         self.steps = []
         self.exampleLines = []
-        
+
         return scenarios
     }
 }

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -75,7 +75,7 @@ class ParseState {
         let globalParamOpeningChar = "{{"
         let globalParamClosingChar = "}}"
 
-        if steps.filter({ $0.expression.contains(globalParamOpeningChar) &&  $0.expression.contains(globalParamClosingChar) }).count > 0 &&
+        if steps.filter({ $0.expression.contains(globalParamOpeningChar) && $0.expression.contains(globalParamClosingChar) }).count > 0 &&
             ParseState.globalParams != nil {
             for stepIndex in 0..<steps.count where steps[stepIndex].expression.contains(globalParamOpeningChar) && steps[stepIndex].expression.contains(globalParamClosingChar) {
                 for (key, value) in ParseState.globalParams! where steps[stepIndex].expression.contains("\(globalParamOpeningChar)\(key)\(globalParamClosingChar)") {


### PR DESCRIPTION
Implementing global variable consumption and substitution. The variables can be in both step lines, and examples tables.

Test Jenkins run - https://build.pyrsoftware.ca/blue/organizations/jenkins/Mobile%2FISP%20Native%20Nightly%20Automation%20Test%20Run/detail/ISP%20Native%20Nightly%20Automation%20Test%20Run/1760/pipeline/52#step-66-log-3464

that uses the changes to tests in https://github.com/Flutter-International-Sports-Platforms/native-ios/commit/c2959a8bfb3891053113efc176def0e9397f7d07 (see the format `{{variableName}}`

![Screenshot 2022-08-15 at 14 00 59](https://user-images.githubusercontent.com/77737913/184639717-3aa6e164-23b9-44e5-9350-d8972193c9bf.png)

