### PR TITLE
Improve indexing for more than 9 examples

### DIFF
--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -104,7 +104,7 @@ class ParseState {
                     }
                 }
             }
-            
+
             for exampleIndex in 0...self.examples.count - 1 {
                 var newSteps = steps
                 var newName = name
@@ -120,7 +120,8 @@ class ParseState {
                 // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in
                 let nameAlreadyExists = scenarios.firstIndex(where: { $0.name == newName })
                 if (newName == name)  || (nameAlreadyExists != nil) {
-                    newName = "\(newName)-\(exampleIndex)"
+                    let zeroedIndex = String(format: "%0\(String(self.examples.count).count)d", exampleIndex)
+                    newName = "\(newName)-\(zeroedIndex)"
                 }
 
                 scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -120,7 +120,8 @@ class ParseState {
                 // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in
                 let nameAlreadyExists = scenarios.firstIndex(where: { $0.name == newName })
                 if (newName == name)  || (nameAlreadyExists != nil) {
-                    let zeroedIndex = String(format: "%0\(String(self.examples.count).count)d", exampleIndex)
+                    let lengthOfExampleCount = String(self.examples.count).count
+                    let zeroedIndex = String(format: "%0\(lengthOfExampleCount)d", exampleIndex)
                     newName = "\(newName)-\(zeroedIndex)"
                 }
 


### PR DESCRIPTION
in the reports we're seeing examples with more than 9 examples appear in the order 0, 1, 10, 11, 12...2, 20, 21. This PR adds leading zeroes as appropriate, e.g.

for <10 examples: 0,1,2,3,...
for >9 examples: 00, 01, 02, 03...10, 11, 12

and it's dynamic, so in theory it would also work for >99 examples, however hopefully that'll never happen.

see logs in https://build.pyrsoftware.ca/blue/organizations/jenkins/Mobile%2FISP%20Native%20Nightly%20Automation%20Test%20Run/detail/ISP%20Native%20Nightly%20Automation%20Test%20Run/1934/pipeline/84#step-94-log-1097 to see it working